### PR TITLE
Update documentation site with Just-the-Docs theme

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,11 +39,11 @@ jobs:
         id: pages
         uses: actions/configure-pages@v4
         
+      - name: Install dependencies
+        run: bundle install
+        
       - name: Build site
-        working-directory: docs
-        run: |
-          bundle install
-          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
           

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "github-pages", group: :jekyll_plugins
+gem "jekyll", "~> 4.3.2"
 gem "just-the-docs", "~> 0.7.0"
 
 group :jekyll_plugins do
@@ -8,3 +8,14 @@ group :jekyll_plugins do
   gem "jekyll-seo-tag"
   gem "jekyll-feed"
 end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]


### PR DESCRIPTION
This PR updates the documentation site to use the Just-the-Docs theme and sets up proper GitHub Pages deployment.

Changes:
- Added Just-the-Docs theme configuration
- Updated site branding and styling
- Set up GitHub Actions workflow for Jekyll deployment
- Updated Gemfile for Jekyll 4.3.2 compatibility
- Configured proper baseurl handling